### PR TITLE
Paratest compatible autoloader class suffix

### DIFF
--- a/src/main/Monorepo/Composer/AutoloadGenerator.php
+++ b/src/main/Monorepo/Composer/AutoloadGenerator.php
@@ -2,9 +2,12 @@
 
 namespace Monorepo\Composer;
 
+use Composer\Config;
 use Composer\Installer\InstallationManager;
+use Composer\Package\Locker;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
+use Composer\Repository\InstalledRepositoryInterface;
 
 class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
 {
@@ -15,6 +18,19 @@ class AutoloadGenerator extends \Composer\Autoload\AutoloadGenerator
         $packageMap[0][1] = $installationManager->getInstallPath($mainPackage); // hack the install path
 
         return $packageMap;
+    }
+
+    // Overrides the $suffix to one that is unique within a monorepo module
+    //
+    // This is necessary for compatibility with paratest. The default behavior of composer v2 uses the hash
+    // of the composer.json file as the suffix for the ComposerAutoloaderInit class. This results in duplicate
+    // class names throughout the monorepo.
+    //
+    // Replacing the default suffix with the hash of the targetDir provides sufficient uniqueness across each
+    // of the modules.
+    public function dump(Config $config, InstalledRepositoryInterface $localRepo, RootPackageInterface $rootPackage, InstallationManager $installationManager, string $targetDir, bool $scanPsrPackages = false, ?string $suffix = null, ?Locker $locker = null, bool $strictAmbiguous = false) {
+	$moduleSuffix = md5($targetDir);
+        return parent::dump($config, $localRepo, $rootPackage, $installationManager, $targetDir, $scanPsrPackages, $moduleSuffix, $locker, $strictAmbiguous);
     }
 
     protected function getFileIdentifier(PackageInterface $package, $path): string


### PR DESCRIPTION
Composer's behavior changed to reuse the composer.lock hash as the suffix for the ComposerAutoloaderInit$suffix class names. This consistency meant each autoloader_real.php file generated by the monorepo plugin had the same class name. This is incompatible with paratest because it tries to load multiple classes with the same name. The reason paratest does this isn't known.

Fixed by using the $targetDir to generate the hash, instead of the lock file.